### PR TITLE
Fix typo

### DIFF
--- a/examples/PCA9634_test_multiple/PCA9634_test_multiple.ino
+++ b/examples/PCA9634_test_multiple/PCA9634_test_multiple.ino
@@ -2,7 +2,7 @@
 //    FILE: PCA9634_test_multiple.ino
 //  AUTHOR: Rob Tillaart
 //    DATE: 2022-01-03
-// PUPROSE: test PCA9634 library
+// PURPOSE: test PCA9634 library
 
 
 #include "Arduino.h"


### PR DESCRIPTION
PUPROSE -> PURPOSE