### PR TITLE
Minor additions for improved communication efficiency (test_86 branch…

### DIFF
--- a/PCA9634.cpp
+++ b/PCA9634.cpp
@@ -108,6 +108,35 @@ uint8_t PCA9634::writeN(uint8_t channel, uint8_t* arr, uint8_t count)
 }
 
 
+uint8_t PCA9634::writeN_noStop(uint8_t channel, uint8_t* arr, uint8_t count)
+{
+  if (channel + count > _channelCount)
+  {
+    _error = PCA9634_ERR_WRITE;
+    return PCA9634_ERROR;
+  }
+  uint8_t base = PCA9634_PWM(channel);
+  _wire->beginTransmission(_address);
+  _wire->write(base);
+  for(uint8_t i = 0; i < count; i++)
+  {
+    _wire->write(arr[i]);
+  }
+  return PCA9634_OK;  // <-- I am not sure if a check for error should be included here. I just added "return PCA9634_OK;", because my compiler told me that I need an uint8_t to return.
+}
+
+uint8_t PCA9634::writeStop()
+{
+  _error = _wire->endTransmission();
+  if (_error != 0)
+  {
+    _error = PCA9634_ERR_I2C;
+    return PCA9634_ERROR;
+  }
+  return PCA9634_OK;
+}
+
+
 uint8_t PCA9634::writeMode(uint8_t reg, uint8_t value)
 {
   if ((reg == PCA9634_MODE1) || (reg == PCA9634_MODE2))

--- a/PCA9634.h
+++ b/PCA9634.h
@@ -59,10 +59,15 @@
 #define PCA9634_MODE2_TOTEMPOLE     0x04  //  0 = open drain   1 = totem-pole
 #define PCA9634_MODE2_NONE          0x00
 
-//  (since 0.2.0)
+// Registers in which the ALLCALL and subaddresses are stored
 #define PCA9634_SUBADR(x)           (0x0D +(x))  // x = 1..3
 #define PCA9634_ALLCALLADR          0x11
 
+// Standard ALLCALL and subaddresses --> only work for write commands and NOT for read commands
+#define PCA9634_ALLCALL             0x70            // TDS of chip says 0xE0, however, in this library the LSB is added wuring the write command (0xE0 --> 0b11100000, 0x70 --> 0b1110000)
+#define PCA9634_SUB1                0x71            // see line above (0xE2 --> 0x71)
+#define PCA9634_SUB2                0x72            // see line above (0xE4 --> 0x72)
+#define PCA9634_SUB3                0x74            // see line above (0xE8 --> 0x74)
 
 class PCA9634
 {
@@ -93,7 +98,13 @@ public:
   //  generic worker, write N consecutive PWM registers
   uint8_t  writeN(uint8_t channel, uint8_t* arr, uint8_t count);
 
-  //  reg = 1, 2  check datasheet for values
+  // generic worker, write N consecutive PWM registers without Stop command
+  uint8_t  writeN_noStop(uint8_t channel, uint8_t* arr, uint8_t count);
+
+  // write stop command to end transmission
+  uint8_t  writeStop();
+  
+  // reg = 1, 2  check datasheet for values
   uint8_t  writeMode(uint8_t reg, uint8_t value);
   uint8_t  readMode(uint8_t reg);
   //   convenience wrappers


### PR DESCRIPTION
…) (#20)

* Added AllCall and Subcall addresses

Changed missleading comment and added relevant standard addresses of the PCA9634 chip

* Added writeN_noStop

* added writeStop

* Added write_noStop and writeStop

As I am not very familiar with arduino (yet) I am really unsure, if the sopy & paste I did makes a lot of sense. Please examine the code carefully. I removed the part which is now in writeStop from the writeN-function and called it writeN_noStop. I need to get a second test board running to actually test if this works as intended.

* Small error correction

Code has been tested and seems to work. I am not sure if there are some edge cases which might cause problems...

* Update PCA9634.h

Fixed adressing issues for AllCallAddress. Here the TDS makes a correct claim which was interpreted wrong by me. In detail: the TDS mentiones the address 0xE0 as AllCall-address. This is correct, however this is an 8 bit address. The LSB (here 0) needs to be ommited when using this library, as it is added during the PCA9634.write() function. Therefore all four addresses (AllCall and Sub1 to Sub3) need to be sortened by the LSB. Then they work flawlessly.

Co-authored-by: Rob Tillaart <rob.tillaart@gmail.com>